### PR TITLE
add_touch_method

### DIFF
--- a/app/models/mailboxer/message.rb
+++ b/app/models/mailboxer/message.rb
@@ -5,7 +5,7 @@ class Mailboxer::Message < Mailboxer::Notification
   # method in gem socialization
   acts_as_mentioner
 
-  belongs_to :conversation, :class_name => "Mailboxer::Conversation", :validate => true, :autosave => true
+  belongs_to :conversation, :class_name => "Mailboxer::Conversation", :validate => true, :autosave => true, touch: true
   validates_presence_of :sender
 
   class_attribute :on_deliver_callback

--- a/app/models/mailboxer/receipt.rb
+++ b/app/models/mailboxer/receipt.rb
@@ -4,7 +4,7 @@ class Mailboxer::Receipt < ActiveRecord::Base
 
   belongs_to :notification, :class_name => "Mailboxer::Notification", :validate => true, :autosave => true
   belongs_to :receiver, :polymorphic => :true
-  belongs_to :message, :class_name => "Mailboxer::Message", :foreign_key => "notification_id"
+  belongs_to :message, :class_name => "Mailboxer::Message", :foreign_key => "notification_id", touch: true
 
   validates_presence_of :receiver
 


### PR DESCRIPTION
加入touch-由於即時通左側列表的項目中conversation有使用到cache，然而receipt被標記為已讀時conversation並不會更新，因此conversation的cache不會被更新。加入touch可以在receipt更新為已讀的同時更新conversation的updated_at，來達到更新conversation的cache作用。